### PR TITLE
OP_RETURN

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -6,6 +6,23 @@ import logging
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+def op_return(bot, update):
+	try:
+		user = update.message.from_user
+		info = getaddress(user.id)
+		
+		op_return = update.message.text.replace('/op_return ', '')
+
+		msg = sendTx(info, 0.001, info[0], op_return)
+		
+	except:
+		msg = "Error de formato >:C\n\n"
+		msg += "Modo de uso: /op_return mensaje"
+
+	logger.info("op_return(%i) => %s" % (user.id, msg))
+	update.message.reply_text("%s" % msg)			
+
+
 def sendall(bot, update, args):
 	try:
 		user = update.message.from_user
@@ -60,7 +77,7 @@ def balance(bot, update):
 	except:
 		msg = "No se pudo ejecutar la lectura de balance :C"
 
-	logger.info("balance(%i) => %s" % (user.id, msg))
+	logger.info("balance(%i) => %s" % (user.id, msg.replace('\n', '')))
 	update.message.reply_text("%s" % msg)
 
 def error(bot, update, error):
@@ -78,6 +95,7 @@ def main():
 
 	# Listado de comandos
 	dp.add_handler(CommandHandler("balance", balance))
+	dp.add_handler(CommandHandler("op_return", op_return))
 	dp.add_handler(CommandHandler("send", send, pass_args=True))
 	dp.add_handler(CommandHandler("sendall", sendall, pass_args=True))
 

--- a/__main__.py
+++ b/__main__.py
@@ -7,13 +7,18 @@ logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=lo
 logger = logging.getLogger(__name__)
 
 def sendall(bot, update, args):
-	user = update.message.from_user
-	info = getaddress(user.id)
-	
-	receptor = args[0]
+	try:
+		user = update.message.from_user
+		info = getaddress(user.id)
+		
+		receptor = args[0]
 
-	max_amount = getbalance(info[0])[0]
-	msg = sendTx(info, max_amount, receptor, 'Quirquincho')
+		max_amount = getbalance(info[0])[0]
+		msg = sendTx(info, max_amount, receptor, 'Quirquincho')
+		
+	except:
+		msg = "Error de formato >:C\n\n"
+		msg += "Modo de uso: /sendall address"
 
 	logger.info("sendall(%i) => %s" % (user.id, msg))
 	update.message.reply_text("%s" % msg)			

--- a/__main__.py
+++ b/__main__.py
@@ -13,7 +13,7 @@ def sendall(bot, update, args):
 	receptor = args[0]
 
 	max_amount = getbalance(info[0])[0]
-	msg = sendTx(info, max_amount, receptor)
+	msg = sendTx(info, max_amount, receptor, 'Quirquincho')
 
 	logger.info("sendall(%i) => %s" % (user.id, msg))
 	update.message.reply_text("%s" % msg)			
@@ -26,7 +26,7 @@ def send(bot, update, args):
 		amount = float(args[0])
 		receptor = args[1]
 
-		msg = sendTx(info, amount, receptor)
+		msg = sendTx(info, amount, receptor, 'Quirquincho')
 
 	except:
 		msg = "Error de formato >:C\n\n"


### PR DESCRIPTION
Incluido soporte para utilizar el opcode OP_RETURN en transacciones, lo que permite acercar a los usuarios de Quirquincho a la utilización del blockchain para almacenar información.

Modo de uso:
```/op_return <mensaje>```

Transacción de prueba:
[bea6d19126612bbb9080d8ecf1781490ee312ea53ec9390b0878503c188bb48a](http://insight.chaucha.cl/tx/bea6d19126612bbb9080d8ecf1781490ee312ea53ec9390b0878503c188bb48a)