### PR TITLE
Update config.py.example

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -18,7 +18,7 @@ MAX_FEE = 0.1
 COIN = 1e8
 
 # API URL
-INSIGHT = 'https://explorer.cha.terahash.cl/'
+INSIGHT = 'https://explorer.cha.terahash.cl'
 
 # JSON Define
 DEFINE = 'https://raw.githubusercontent.com/panterozo/api-chaucha/master/glosario.json'


### PR DESCRIPTION
Se quita '/' para que no se repita ese signo cuando el bot entregue las URLs de las tx.
Detalles, no más